### PR TITLE
Added a function to get the direction cosines of the image

### DIFF
--- a/src/image.js
+++ b/src/image.js
@@ -175,6 +175,13 @@ daikon.Image.prototype.getImagePosition = function () {
     return daikon.Image.getValueSafely(this.getTag(daikon.Tag.TAG_IMAGE_POSITION[0], daikon.Tag.TAG_IMAGE_POSITION[1]));
 };
 
+/**
+ * Returns the image axis directions
+ * @return {number[]}
+ */
+daikon.Image.prototype.getImageDirections = function () {
+    return daikon.Image.getValueSafely(this.getTag(daikon.Tag.TAG_IMAGE_ORIENTATION[0], daikon.Tag.TAG_IMAGE_ORIENTATION[1]))
+}
 
 
 /**


### PR DESCRIPTION
Just what the title says. It is a convenience function to get the direction cosines from the DICOM header, so they can later be used to properly build the image orientation transform in space.