### PR TITLE
fix: for avoiding fragmentation in array allocation

### DIFF
--- a/src/image.js
+++ b/src/image.js
@@ -581,7 +581,7 @@ daikon.Image.prototype.getInterpretedData = function (asArray, asObject) {
     littleEndian = this.littleEndian;
 
     if (asArray) {
-        data = [];
+        data = new Array(numElements);
     } else {
         data = new Float32Array(numElements);
     }


### PR DESCRIPTION
Pre-allocating the array is faster and avoids memory fragmentation.