### PR TITLE
fix: `getInterpretedData()` returns all-zeroes for certain image types

### DIFF
--- a/src/image.js
+++ b/src/image.js
@@ -567,7 +567,7 @@ daikon.Image.prototype.getInterpretedData = function (asArray, asObject) {
         maxIndex, littleEndian, rawValue, rawData;
     mask = daikon.Utils.createBitMask(this.getBitsAllocated() / 8, this.getBitsStored(),
         this.getDataType() === daikon.Image.BYTE_TYPE_INTEGER_UNSIGNED);
-    datatype = this.getDataType();
+    datatype = this.getPixelRepresentation() ? daikon.Image.BYTE_TYPE_INTEGER : daikon.Image.BYTE_TYPE_INTEGER_UNSIGNED;
     numBytes = this.getBitsAllocated() / 8;
     rawData = this.getRawData();
     dataView = new DataView(rawData);


### PR DESCRIPTION
This library uses custom data type codes for things like RGB, but `getInterpolatedData()` does not recognize this and so only looks for the standard two formats (signed, unsigned).