### PR TITLE
Bug fixes to be able to read dicom-web data

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -172,7 +172,7 @@ daikon.Parser.prototype.testForValidTag = function (data) {
 
     try {
         offset = this.findFirstTagOffset(data);
-        tag = this.getNextTag(data, offset, true);
+        tag = this.getNextTag(data, offset, false);
     } catch (err) {
         this.error = err;
     }

--- a/src/parser.js
+++ b/src/parser.js
@@ -372,7 +372,7 @@ daikon.Parser.prototype.parseSublistItem = function (data, offset, raw) {
 daikon.Parser.prototype.findFirstTagOffset = function (data) {
     var offset = 0,
         magicCookieLength = daikon.Parser.MAGIC_COOKIE.length,
-        searchOffsetMax = daikon.Parser.MAGIC_COOKIE_OFFSET * 2,
+        searchOffsetMax = daikon.Parser.MAGIC_COOKIE_OFFSET * 5,
         found = false,
         ctr = 0,
         ctrIn = 0,
@@ -382,7 +382,7 @@ daikon.Parser.prototype.findFirstTagOffset = function (data) {
         offset = daikon.Parser.MAGIC_COOKIE_OFFSET + magicCookieLength;
     } else {
         for (ctr = 0; ctr < searchOffsetMax; ctr += 1) {
-            ch = data.getUint8(offset);
+            ch = data.getUint8(ctr);
             if (ch === daikon.Parser.MAGIC_COOKIE[0]) {
                 found = true;
                 for (ctrIn = 1; ctrIn < magicCookieLength; ctrIn += 1) {
@@ -392,7 +392,7 @@ daikon.Parser.prototype.findFirstTagOffset = function (data) {
                 }
 
                 if (found) {
-                    offset = ctr;
+                    offset = ctr + magicCookieLength;
                     break;
                 }
             }


### PR DESCRIPTION
These two commits are bug fixes so that dicoms with non-standard magic cookie offsets are read correctly. In particular, these should now enable reading of dicom instances from dicom-web sources e.g Orthanc with dicom-web plugin, to be parsed correctly since dicom-web responses are multi-part mime messages and having a large offset for the marker allows for the mime header to be skipped correctly